### PR TITLE
Refactor security middleware integration for FastMCP server

### DIFF
--- a/obsidian-remote-mcp/tests/test_server_http_app.py
+++ b/obsidian-remote-mcp/tests/test_server_http_app.py
@@ -1,0 +1,23 @@
+"""Regression tests for HTTP app construction."""
+
+from obsidian_remote_mcp.paths import Vault
+from obsidian_remote_mcp.server import Settings, create_server
+
+
+def test_http_app_builds_with_security_middleware(tmp_path):
+    vault_root = tmp_path / "vault"
+    vault_root.mkdir()
+
+    settings = Settings(
+        vaults={"vault": Vault("vault", vault_root)},
+        host="127.0.0.1",
+        port=0,
+        shared_secret="super-secret",
+        log_level="INFO",
+    )
+
+    server, security_middleware = create_server(settings)
+
+    app = server.http_app(middleware=security_middleware)
+
+    assert app is not None


### PR DESCRIPTION
## Summary
- build security middleware as Starlette `Middleware` entries instead of mutating the FastAPI app directly
- refactor the server to use `custom_route` for the health check and return the security middleware alongside the FastMCP instance
- add a regression test ensuring the HTTP app can be created with the security middleware applied

## Testing
- PYTHONPATH=src pytest

------
https://chatgpt.com/codex/tasks/task_e_68dd938ad03483319ab84c0cd6f9e33e