### PR TITLE
Allow running without shared secret

### DIFF
--- a/obsidian-remote-mcp/.env.example
+++ b/obsidian-remote-mcp/.env.example
@@ -1,4 +1,5 @@
 VAULT_PATHS=/absolute/path/to/your/vault
+# Leave blank to disable auth (only for trusted setups)
 MCP_SHARED_SECRET=please-change-me
 HOST=0.0.0.0
 PORT=8000

--- a/obsidian-remote-mcp/src/obsidian_remote_mcp/server.py
+++ b/obsidian-remote-mcp/src/obsidian_remote_mcp/server.py
@@ -37,7 +37,7 @@ class Settings:
     vaults: Mapping[str, Vault]
     host: str
     port: int
-    shared_secret: str
+    shared_secret: str | None
     log_level: str
 
 
@@ -210,8 +210,6 @@ def load_settings() -> Settings:
     host = os.environ.get("HOST", "0.0.0.0")  # noqa: S104 (intentional bind)
     port = int(os.environ.get("PORT", "8000"))
     shared_secret = os.environ.get("MCP_SHARED_SECRET")
-    if not shared_secret:
-        raise RuntimeError("MCP_SHARED_SECRET must be configured")
 
     log_level = os.environ.get("LOG_LEVEL", "info").upper()
     logging.basicConfig(level=getattr(logging, log_level, logging.INFO))

--- a/obsidian-remote-mcp/tests/test_server_http_app.py
+++ b/obsidian-remote-mcp/tests/test_server_http_app.py
@@ -21,3 +21,22 @@ def test_http_app_builds_with_security_middleware(tmp_path):
     app = server.http_app(middleware=security_middleware)
 
     assert app is not None
+
+
+def test_http_app_builds_without_shared_secret(tmp_path):
+    vault_root = tmp_path / "vault"
+    vault_root.mkdir()
+
+    settings = Settings(
+        vaults={"vault": Vault("vault", vault_root)},
+        host="127.0.0.1",
+        port=0,
+        shared_secret=None,
+        log_level="INFO",
+    )
+
+    server, security_middleware = create_server(settings)
+
+    app = server.http_app(middleware=security_middleware)
+
+    assert app is not None


### PR DESCRIPTION
## Summary
- allow the shared-secret middleware to be skipped when no MCP_SHARED_SECRET is configured
- document the optional authentication flow and update the sample environment file
- add a regression test covering server creation without a shared secret

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68dd971332f883318e1107aae1f99b3e