### PR TITLE
Allow search tool default vault root when omitted

### DIFF
--- a/obsidian-remote-mcp/src/obsidian_remote_mcp/server.py
+++ b/obsidian-remote-mcp/src/obsidian_remote_mcp/server.py
@@ -184,9 +184,19 @@ class NoteService:
         except Exception as exc:
             return {"ok": False, "error": str(exc)}
 
-    def search_vault(self, root: str, query: str, max_results: int = 50) -> dict[str, Any]:
+    def search_vault(
+        self, query: str, root: str | None = None, max_results: int = 50
+    ) -> dict[str, Any]:
         try:
-            vault_root = resolve_directory_path(root, self.vaults)
+            if root is None:
+                if len(self.vaults) == 1:
+                    vault_root = next(iter(self.vaults.values())).root
+                else:
+                    raise ValueError(
+                        "Multiple vaults configured; specify the 'root' parameter"
+                    )
+            else:
+                vault_root = resolve_directory_path(root, self.vaults)
             results = search_vault_content(vault_root, query, max_results)
             return {"ok": True, "ids": results}
         except Exception as exc:
@@ -292,12 +302,16 @@ def create_server(settings: Settings | None = None) -> tuple[FastMCP, list[Middl
         return service.rename_tag(old, new, root)
 
     @tool()
-    async def search_vault(root: str, query: str, max_results: int = 50) -> dict[str, Any]:
-        return service.search_vault(root, query, max_results)
+    async def search_vault(
+        query: str, root: str | None = None, max_results: int = 50
+    ) -> dict[str, Any]:
+        return service.search_vault(query, root, max_results)
 
     @tool(name="search")
-    async def search_alias(root: str, query: str, max_results: int = 50) -> dict[str, Any]:
-        return service.search_vault(root, query, max_results)
+    async def search_alias(
+        query: str, root: str | None = None, max_results: int = 50
+    ) -> dict[str, Any]:
+        return service.search_vault(query, root, max_results)
 
     @tool()
     async def fetch(note_id: str) -> dict[str, Any]:

--- a/obsidian-remote-mcp/tests/test_server_smoke.py
+++ b/obsidian-remote-mcp/tests/test_server_smoke.py
@@ -19,7 +19,7 @@ def test_note_service_smoke(tmp_path):
     manage = service.manage_tags("vault/hello")
     assert "#demo" in manage["tags"]
 
-    search = service.search_vault("vault", "hello")
+    search = service.search_vault("hello", root="vault")
     assert search["ids"]
 
     fetch = service.fetch(search["ids"][0])
@@ -30,3 +30,32 @@ def test_note_service_smoke(tmp_path):
 
     delete = service.delete_note("vault/hello")
     assert delete["ok"]
+
+
+def test_search_vault_defaults_to_single_vault(tmp_path):
+    root = tmp_path / "vault"
+    root.mkdir()
+    service = NoteService({"vault": Vault("vault", root)})
+
+    (root / "note.md").write_text("Needle", encoding="utf-8")
+
+    result = service.search_vault("Needle")
+    assert result["ok"] and result["ids"]
+
+
+def test_search_vault_requires_root_for_multiple_vaults(tmp_path):
+    root_a = tmp_path / "vault-a"
+    root_b = tmp_path / "vault-b"
+    root_a.mkdir()
+    root_b.mkdir()
+
+    service = NoteService(
+        {
+            "vault-a": Vault("vault-a", root_a),
+            "vault-b": Vault("vault-b", root_b),
+        }
+    )
+
+    result = service.search_vault("anything")
+    assert not result["ok"]
+    assert "multiple vaults" in result["error"].lower()


### PR DESCRIPTION
## Summary
- allow `NoteService.search_vault` to infer the vault when none is provided and surface an error when multiple vaults exist
- update the FastMCP search tool registrations so that `query` is the only required argument
- extend smoke tests to cover default vault selection and the multi-vault guard

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dd9d9e0c508331b5a23cdb54f9e699