### PR TITLE
Add id parameter support to fetch tool

### DIFF
--- a/obsidian-remote-mcp/tests/test_server_smoke.py
+++ b/obsidian-remote-mcp/tests/test_server_smoke.py
@@ -25,6 +25,13 @@ def test_note_service_smoke(tmp_path):
     fetch = service.fetch(search["ids"][0])
     assert fetch["ok"] and fetch["content"]
 
+    fetch_by_id = service.fetch(id=search["ids"][0])
+    assert fetch_by_id["ok"] and fetch_by_id["content"]
+
+    missing_identifier = service.fetch(note_id=None, id=None)
+    assert not missing_identifier["ok"]
+    assert "missing" in missing_identifier["error"].lower()
+
     rename = service.rename_tag("demo", "demo-renamed", "vault")
     assert rename["replacements"] >= 1
 


### PR DESCRIPTION
## Summary
- allow the fetch service to accept either an `id` or legacy `note_id` value and surface a helpful error when neither is provided
- expose the MCP fetch tool with the `id` parameter required by the specification while keeping backwards compatibility for existing clients
- extend the smoke test to cover fetching with the new parameter and the missing identifier error path

## Testing
- PYTHONPATH=src pytest

------
https://chatgpt.com/codex/tasks/task_e_68dd9f96356483319007b1bac0ee96a5